### PR TITLE
Add calculated expression support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
     (name: 'PRAPARE', value: 1),
     (name: 'PHQ-9', value: 2),
     (name: 'GAD-7', value: 3),
+    (name: 'BMI', value: 4),
   ];
   final List<({String name, InputDecorationTheme? value})>
       inputDecorationThemes = [
@@ -193,17 +194,14 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  /*
   Questionnaire get questionnaire =>
       Questionnaire.fromJsonString(switch (selectedQuestionnaire) {
         1 => QuestionnaireSamples.samplePrapare,
         2 => QuestionnaireSamples.samplePHQ9,
         3 => QuestionnaireSamples.sampleGAD7,
+        4 => QuestionnaireSamples.sampleBmiQuestionnaire,
         0 || _ => QuestionnaireSamples.sampleGeneric,
       });
-  */
-  Questionnaire get questionnaire =>
-      Questionnaire.fromJsonString(QuestionnaireSamples.bmiQuestionnaire);
 }
 
 class QuestionnairePage extends StatefulWidget {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -193,6 +193,7 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
+  /*
   Questionnaire get questionnaire =>
       Questionnaire.fromJsonString(switch (selectedQuestionnaire) {
         1 => QuestionnaireSamples.samplePrapare,
@@ -200,6 +201,9 @@ class _MyHomePageState extends State<MyHomePage> {
         3 => QuestionnaireSamples.sampleGAD7,
         0 || _ => QuestionnaireSamples.sampleGeneric,
       });
+  */
+  Questionnaire get questionnaire =>
+      Questionnaire.fromJsonString(QuestionnaireSamples.bmiQuestionnaire);
 }
 
 class QuestionnairePage extends StatefulWidget {

--- a/example/lib/questionnaire_samples.dart
+++ b/example/lib/questionnaire_samples.dart
@@ -10,7 +10,7 @@ extension QuestionnaireSamples on Questionnaire {
               "valueExpression": {
                 "name": "weight",
                 "language": "text/fhirpath",
-                "expression": "%resource.repeat(item).where(linkId='3.3.1').item.answer.value"
+                "expression": "%resource.repeat(item).where(linkId='3.3.1').answer.value"
               }
             },
             {
@@ -18,7 +18,7 @@ extension QuestionnaireSamples on Questionnaire {
               "valueExpression": {
                 "name": "height",
                 "language": "text/fhirpath",
-                "expression": "%resource.repeat(item).where(linkId='3.3.2').item.answer.value*0.0254"
+                "expression": "%resource.repeat(item).where(linkId='3.3.2').answer.value*0.0254"
               }
             }
           ],

--- a/example/lib/questionnaire_samples.dart
+++ b/example/lib/questionnaire_samples.dart
@@ -1,75 +1,6 @@
 import 'package:fhir/r4.dart';
 
 extension QuestionnaireSamples on Questionnaire {
-  static String get bmiQuestionnaire => '''
-  {
-          "resourceType": "Questionnaire",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/variable",
-              "valueExpression": {
-                "name": "weight",
-                "language": "text/fhirpath",
-                "expression": "%resource.repeat(item).where(linkId='3.3.1').answer.value"
-              }
-            },
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/variable",
-              "valueExpression": {
-                "name": "height",
-                "language": "text/fhirpath",
-                "expression": "%resource.repeat(item).where(linkId='3.3.2').answer.value*0.0254"
-              }
-            }
-          ],
-          "item": [
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "system": "http://unitsofmeasure.org",
-                    "code": "kg"
-                  }
-                }
-              ],
-              "linkId": "3.3.1",
-              "text": "Weight (kg)",
-              "type": "decimal"
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "system": "http://unitsofmeasure.org",
-                    "code": "[in_i]"
-                  }
-                }
-              ],
-              "linkId": "3.3.2",
-              "text": "Body Height (inches)",
-              "type": "decimal"
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
-                  "valueExpression": {
-                    "description": "BMI Calculation",
-                    "language": "text/fhirpath",
-                    "expression": "(%weight/(%height.power(2))).round(1)"
-                  }
-                }
-              ],
-              "linkId": "3.3.3",
-              "text": "Your Body Mass Index (BMI) is ",
-              "type": "decimal",
-              "readOnly": true
-            }
-          ]
-        }
-  ''';
   static String get sampleGeneric => '''
   {
   "resourceType": "Questionnaire",
@@ -2463,5 +2394,74 @@ extension QuestionnaireSamples on Questionnaire {
     ],
     "id": "13d63616-203c-4dcb-a9f1-faa4d45e76ca"
   }
+  ''';
+  static String get sampleBmiQuestionnaire => '''
+  {
+          "resourceType": "Questionnaire",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/variable",
+              "valueExpression": {
+                "name": "weight",
+                "language": "text/fhirpath",
+                "expression": "%resource.repeat(item).where(linkId='3.3.1').answer.value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/variable",
+              "valueExpression": {
+                "name": "height",
+                "language": "text/fhirpath",
+                "expression": "%resource.repeat(item).where(linkId='3.3.2').answer.value*0.0254"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "system": "http://unitsofmeasure.org",
+                    "code": "kg"
+                  }
+                }
+              ],
+              "linkId": "3.3.1",
+              "text": "Weight (kg)",
+              "type": "decimal"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "system": "http://unitsofmeasure.org",
+                    "code": "[in_i]"
+                  }
+                }
+              ],
+              "linkId": "3.3.2",
+              "text": "Body Height (inches)",
+              "type": "decimal"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "description": "BMI Calculation",
+                    "language": "text/fhirpath",
+                    "expression": "(%weight/(%height.power(2))).round(1)"
+                  }
+                }
+              ],
+              "linkId": "3.3.3",
+              "text": "Your Body Mass Index (BMI) is ",
+              "type": "decimal",
+              "readOnly": true
+            }
+          ]
+        }
   ''';
 }

--- a/example/lib/questionnaire_samples.dart
+++ b/example/lib/questionnaire_samples.dart
@@ -1,6 +1,75 @@
 import 'package:fhir/r4.dart';
 
 extension QuestionnaireSamples on Questionnaire {
+  static String get bmiQuestionnaire => '''
+  {
+          "resourceType": "Questionnaire",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/variable",
+              "valueExpression": {
+                "name": "weight",
+                "language": "text/fhirpath",
+                "expression": "%resource.repeat(item).where(linkId='3.3.1').item.answer.value"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/variable",
+              "valueExpression": {
+                "name": "height",
+                "language": "text/fhirpath",
+                "expression": "%resource.repeat(item).where(linkId='3.3.2').item.answer.value*0.0254"
+              }
+            }
+          ],
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "system": "http://unitsofmeasure.org",
+                    "code": "kg"
+                  }
+                }
+              ],
+              "linkId": "3.3.1",
+              "text": "Weight (kg)",
+              "type": "decimal"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "system": "http://unitsofmeasure.org",
+                    "code": "[in_i]"
+                  }
+                }
+              ],
+              "linkId": "3.3.2",
+              "text": "Body Height (inches)",
+              "type": "decimal"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                  "valueExpression": {
+                    "description": "BMI Calculation",
+                    "language": "text/fhirpath",
+                    "expression": "(%weight/(%height.power(2))).round(1)"
+                  }
+                }
+              ],
+              "linkId": "3.3.3",
+              "text": "Your Body Mass Index (BMI) is ",
+              "type": "decimal",
+              "readOnly": true
+            }
+          ]
+        }
+  ''';
   static String get sampleGeneric => '''
   {
   "resourceType": "Questionnaire",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,6 +81,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.0"
+  fhir_path:
+    dependency: transitive
+    description:
+      path: "."
+      ref: update-fhir-0-12-0
+      resolved-ref: "286c5394e9e6ef3e7cea73b08890d36ad2b360ce"
+      url: "https://github.com/evoleen/fhir_path.git"
+    source: git
+    version: "0.11.3"
   fhir_questionnaire:
     dependency: "direct main"
     description:
@@ -436,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  ucum:
+    dependency: transitive
+    description:
+      name: ucum
+      sha256: "45767ceaa8376da962cfabe48facbcdeb27cb92005cf89b6d4abf89d9e2ce796"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   uuid:
     dependency: transitive
     description:

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fhir/r4.dart';
+import 'package:fhir_path/fhir_path.dart';
 import 'package:fhir_questionnaire/fhir_questionnaire.dart';
 import 'package:flutter/foundation.dart';
 
@@ -230,17 +231,265 @@ class QuestionnaireController {
     return answers;
   }
 
+  /// Retrieves all variable definitions defined at the Questionnaire's root
+  /// level and calculates their value. Returns a map of variable name / value
+  /// pairs that can be used as execution context to evaluate expressions at
+  /// a deeper level.
+  Map<String, dynamic> _fetchCalculatedExpressionRootVariables({
+    required Questionnaire questionnaire,
+    required QuestionnaireResponse questionnaireResponse,
+  }) {
+    final calculatedResults = <String, dynamic>{};
+
+    // capture all top-level variables as list, in order
+    final rootExpressions = (questionnaire.extension_ ?? [])
+        .where((ext) =>
+            ext.url ==
+                FhirUri('http://hl7.org/fhir/StructureDefinition/variable') &&
+            ext.valueExpression?.language ==
+                FhirExpressionLanguage.text_fhirpath)
+        .toList();
+
+    for (final exp in rootExpressions) {
+      final expression = exp.valueExpression?.expression;
+      final expressionName = exp.valueExpression?.name?.value;
+
+      if (expression == null) {
+        print('Calculated expression has no expression, skipping.');
+        continue;
+      }
+
+      if (expressionName == null) {
+        print('Calculated expression has no name, skiping.');
+        continue;
+      }
+
+      final result = walkFhirPath(
+        environment: calculatedResults,
+        pathExpression: expression,
+        context: questionnaireResponse.toJson(),
+        resource: questionnaireResponse.toJson(),
+      );
+
+      if (result.isNotEmpty) {
+        calculatedResults['%$expressionName'] = result.first;
+      }
+    }
+
+    return calculatedResults;
+  }
+
+  /// Calculates the number of unresolved calculated expressions in an item
+  /// list. Returns the number of all expression for which no answer value
+  /// exists. The number will be the sum of all expressions in the entire
+  /// sub tree of items.
+  int _nrUnresolvedExpressionsInItemList(
+      {required List<QuestionnaireResponseItem>? itemList}) {
+    if (itemList == null) {
+      return 0;
+    }
+
+    int result = 0;
+
+    for (final item in itemList) {
+      final childItems = item.item;
+
+      if (childItems != null && childItems.isNotEmpty) {
+        result += _nrUnresolvedExpressionsInItemList(itemList: childItems);
+      }
+
+      final calculatedExpressions = (item.extension_ ?? [])
+          .where((ext) =>
+              ext.url ==
+                  FhirUri(
+                      'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression') &&
+              ext.valueExpression?.language ==
+                  FhirExpressionLanguage.text_fhirpath)
+          .toList()
+          .length;
+
+      if (calculatedExpressions > 0 && item.answer == null) {
+        result++;
+      }
+    }
+
+    return result;
+  }
+
+  /// Attempts to resolve exactly one unresolved calculated expression.
+  /// Traverses the tree of items depth-first and will abort after it tried
+  /// to resolve the first matching element.
+  List<QuestionnaireResponseItem>? _resolveFirstCalculatedExpression({
+    required Map<String, dynamic> environment,
+    required List<QuestionnaireResponseItem>? itemList,
+    required QuestionnaireResponse questionnaireResponse,
+  }) {
+    if (itemList == null) {
+      return null;
+    }
+
+    final updatedList = List<QuestionnaireResponseItem>.from(itemList);
+
+    // go depth first
+    for (int itemIndex = 0; itemIndex < updatedList.length; itemIndex++) {
+      if (updatedList[itemIndex].item != null &&
+          _nrUnresolvedExpressionsInItemList(
+                  itemList: updatedList[itemIndex].item) >
+              0) {
+        updatedList[itemIndex] = updatedList[itemIndex].copyWith(
+            item: _resolveFirstCalculatedExpression(
+          environment: environment,
+          itemList: updatedList[itemIndex].item,
+          questionnaireResponse: questionnaireResponse,
+        ));
+
+        return updatedList;
+      }
+    }
+
+    // if we didn't resolve any child elements, find an element at current level
+    for (int itemIndex = 0; itemIndex < updatedList.length; itemIndex++) {
+      // skip items that already have an answer
+      if (updatedList[itemIndex].answer != null) {
+        continue;
+      }
+
+      final calculatedExpressionExtensions = (updatedList[itemIndex]
+                  .extension_ ??
+              [])
+          .where((ext) =>
+              ext.url ==
+                  FhirUri(
+                      'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression') &&
+              ext.valueExpression?.language ==
+                  FhirExpressionLanguage.text_fhirpath)
+          .toList();
+
+      if (calculatedExpressionExtensions.isNotEmpty) {
+        final expression =
+            calculatedExpressionExtensions.first.valueExpression?.expression;
+
+        if (expression == null) {
+          print('Calculated expression has no expression, skipping.');
+          continue;
+        }
+
+        final result = walkFhirPath(
+          environment: environment,
+          pathExpression: expression,
+          context: questionnaireResponse.toJson(),
+          resource: questionnaireResponse.toJson(),
+        );
+
+        if (result.isNotEmpty) {
+          final resultValue = result.first;
+
+          QuestionnaireResponseAnswer? answer;
+
+          if (resultValue is int) {
+            answer = QuestionnaireResponseAnswer(
+              valueInteger: FhirInteger(resultValue),
+            );
+          } else if (resultValue is num) {
+            answer = QuestionnaireResponseAnswer(
+              valueDecimal: FhirDecimal(resultValue),
+            );
+          } else {
+            answer = QuestionnaireResponseAnswer(valueString: resultValue);
+          }
+
+          updatedList[itemIndex] = itemList[itemIndex].copyWith(
+            // insert calculation result as answer
+            answer: [answer],
+            // remove extension to indicate completion
+            // extension_: itemList[itemIndex]
+            //    .extension_
+            //    ?.where((ext) =>
+            //        ext.fhirId !=
+            //        calculatedExpressionExtensions.first.fhirId)
+            //    .toList(),
+          );
+
+          return updatedList;
+        }
+      }
+    }
+
+    return updatedList;
+  }
+
+  /// Takes a list of questionnaire items and calculates their answer value
+  /// if their value is not user input but a calculated expression. Takes
+  /// a map of variable name / value pairs as context input as well as the entire
+  /// questionnaire response object to support entity-wide value lookups.
+  /// The item list will be processed depth-first and then in order, as per
+  /// the FHIR spec.
+  /// Since items may reference each other, the method will try to resolve
+  /// the first expression it finds, then restart at the top. It continues to
+  /// do so until the number of unresolved expressions reaches zero or does
+  /// not decrease anymore, indicating that it encountered an expression with
+  /// an error.
+  /// In case an expression with an error is encountered in the middle of
+  /// processing, all other unresolved expressions will remain unresolved.
+  List<QuestionnaireResponseItem>? _resolveItemsWithCalculatedExpressions({
+    required Map<String, dynamic> environment,
+    required List<QuestionnaireResponseItem>? itemList,
+    required QuestionnaireResponse questionnaireResponse,
+  }) {
+    if (itemList == null) {
+      return null;
+    }
+
+    var currentNumberOfUnresolvedItems = 0;
+    var newNumberOfUnresolvedItems = 0;
+
+    // if we have unresolved items, try to resolve the first and repeat
+    // until we reach 0 or calculations stop resolving
+    do {
+      currentNumberOfUnresolvedItems =
+          _nrUnresolvedExpressionsInItemList(itemList: itemList);
+
+      if (currentNumberOfUnresolvedItems > 0) {
+        itemList = _resolveFirstCalculatedExpression(
+            environment: environment,
+            itemList: itemList,
+            questionnaireResponse: questionnaireResponse);
+      }
+
+      newNumberOfUnresolvedItems =
+          _nrUnresolvedExpressionsInItemList(itemList: itemList);
+    } while (newNumberOfUnresolvedItems > 0 &&
+        newNumberOfUnresolvedItems < currentNumberOfUnresolvedItems);
+
+    return itemList;
+  }
+
   QuestionnaireResponse generateResponse(
       {required Questionnaire questionnaire,
       required List<QuestionnaireItemBundle> itemBundles}) {
     List<QuestionnaireResponseItem> itemResponses =
         generateItemResponses(itemBundles: itemBundles);
 
-    return QuestionnaireResponse(
+    final questionnaireResponse = QuestionnaireResponse(
       questionnaire: questionnaire.asFhirCanonical,
       status: QuestionnaireResponseStatus.completed.asFhirCode,
       item: itemResponses,
     );
+
+    final environment = _fetchCalculatedExpressionRootVariables(
+      questionnaire: questionnaire,
+      questionnaireResponse: questionnaireResponse,
+    );
+
+    final updatedQuestionnaireResponse = questionnaireResponse.copyWith(
+      item: _resolveItemsWithCalculatedExpressions(
+        itemList: questionnaireResponse.item,
+        environment: environment,
+        questionnaireResponse: questionnaireResponse,
+      ),
+    );
+
+    return updatedQuestionnaireResponse;
   }
 
   List<QuestionnaireResponseItem> generateItemResponses(
@@ -355,6 +604,7 @@ class QuestionnaireController {
         definition: itemBundle.item.definition,
         text: itemBundle.item.text,
         answer: answers.isEmpty ? null : answers,
+        extension_: itemBundle.item.extension_,
       ));
     }
 

--- a/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_item_view.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:fhir_questionnaire/src/logic/utils/text_utils.dart';
 import 'package:fhir_questionnaire/src/model/questionnaire_item_enable_when_controller.dart';
 import 'package:fhir_questionnaire/src/presentation/utils/validation_utils.dart';
@@ -34,6 +35,15 @@ abstract class QuestionnaireItemViewState<SF extends QuestionnaireItemView>
   int? get maxLength => item.maxLength?.value;
   @override
   bool get wantKeepAlive => false;
+
+  bool get isHidden =>
+      (item.extension_ ?? [])
+          .firstWhereOrNull((ext) =>
+              ext.url ==
+              FhirUri(
+                  'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden'))
+          ?.valueBoolean ==
+      FhirBoolean(true);
 
   bool get handleControllerErrorManually => true;
 
@@ -77,19 +87,21 @@ abstract class QuestionnaireItemViewState<SF extends QuestionnaireItemView>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return AnimatedSize(
-      duration: const Duration(milliseconds: 300),
-      child: SizedBox(
-        height: isEnabled ? null : 0,
-        child: SizeRenderer(
-          onSizeRendered: onSizeRendered,
-          child: Padding(
-            padding: const EdgeInsets.only(bottom: 24.0),
-            child: buildBody(context),
-          ),
-        ),
-      ),
-    );
+    return isHidden
+        ? const SizedBox.shrink()
+        : AnimatedSize(
+            duration: const Duration(milliseconds: 300),
+            child: SizedBox(
+              height: isEnabled ? null : 0,
+              child: SizeRenderer(
+                onSizeRendered: onSizeRendered,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 24.0),
+                  child: buildBody(context),
+                ),
+              ),
+            ),
+          );
   }
 
   void onSizeRendered(Size size, GlobalKey key) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,7 @@ dependencies:
   collection: ^1.18.0
   shimmer: ^3.0.0
   fhir: ^0.12.0
-  fhir_path:
-    git:
-      url: https://github.com/evoleen/fhir_path.git
-      ref: update-fhir-0-12-0
+  fhir_path: ^0.12.0
   intl: ^0.19.0
   validators: ^3.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,10 @@ dependencies:
   collection: ^1.18.0
   shimmer: ^3.0.0
   fhir: ^0.12.0
+  fhir_path:
+    git:
+      url: https://github.com/evoleen/fhir_path.git
+      ref: update-fhir-0-12-0
   intl: ^0.19.0
   validators: ^3.0.0
 


### PR DESCRIPTION
This change adds a first, simple support for `calculatedExpression` of the Structured Data Capture extension:
- it is able to calculate the value of variables defined through fhirpath expressions
- it is able to calculate answer values of questions that are composed of fhirpath expressions

It additionally supports hidden elements, which are commonly used to store result values.

Note: can only be merged once required changes to `fhir_path` have been merged upstream.