### PR TITLE
Set groupId on QuestionnaireItemBundle

### DIFF
--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -85,8 +85,10 @@ class QuestionnaireController {
   }
 
   List<QuestionnaireItemBundle> buildQuestionnaireItemBundles(
-      List<QuestionnaireItem>? questionnaireItems,
-      {required Future<Attachment?> Function()? onAttachmentLoaded}) {
+    List<QuestionnaireItem>? questionnaireItems, {
+    required Future<Attachment?> Function()? onAttachmentLoaded,
+    String? groupId,
+  }) {
     List<QuestionnaireItemBundle> itemBundles = [];
     try {
       for (final QuestionnaireItem item in questionnaireItems ?? []) {
@@ -171,8 +173,14 @@ class QuestionnaireController {
             );
             break;
           case QuestionnaireItemType.group:
-            children = buildQuestionnaireItemBundles(item.item,
-                onAttachmentLoaded: onAttachmentLoaded);
+            final groupIdForChildren =
+                '${groupId != null ? "$groupId/" : ""}${item.linkId}';
+
+            children = buildQuestionnaireItemBundles(
+              item.item,
+              onAttachmentLoaded: onAttachmentLoaded,
+              groupId: groupIdForChildren,
+            );
             itemView = QuestionnaireGroupItemView(
               item: item,
               enableWhenController: enableWhenController,
@@ -187,6 +195,7 @@ class QuestionnaireController {
             view: itemView,
             children: children,
             controller: itemView.controller,
+            groupId: groupId,
           ));
         }
       }

--- a/lib/src/model/questionnaire_item_bundle.dart
+++ b/lib/src/model/questionnaire_item_bundle.dart
@@ -11,10 +11,14 @@ class QuestionnaireItemBundle {
   final QuestionnaireItemView view;
 
   const QuestionnaireItemBundle({
-    this.groupId,
+    required this.groupId,
     required this.item,
     this.children,
     required this.controller,
     required this.view,
   });
+
+  /// Returns linkId of the questionnaire [item] prefixed by its parent item
+  /// link ids, showing a unique id for this questionnaire [item].
+  String get uid => '$groupId/${item.linkId}';
 }


### PR DESCRIPTION
1. Sets `groupId` property value for `QuestionnaireBundleItem` objects
2. Adds a unic id getter method on `QuestionnaireBundleItem` that shows a unic id which is the linkId of the `item` property prefixed by its parent groupIds.


eg: for questionnaire item defined below with linkId 3 the groupId would be `1/2` and the uid will be `1/2/3`. This is similar to unic id that was assigned in faiadashu library. I think the similarity would help new users of fhir_questionnaire that are moving away from faiadashu

```json
{
    "linkId": "1",
    "type": "group",
    "item": [
        {
            "linkId": "2",
            "type": "group",
            "item":[
                {
                    "linkId":"3",
                    "type": "text"
                }
            ]
        }
    ]
}
```
