### PR TITLE
Make checkIfEnabled public

### DIFF
--- a/lib/src/model/questionnaire_item_enable_when_controller.dart
+++ b/lib/src/model/questionnaire_item_enable_when_controller.dart
@@ -17,7 +17,7 @@ class QuestionnaireItemEnableWhenController {
   bool init({required ValueChanged<bool> onEnabledChangedListener}) {
     _onEnabledChanged = onEnabledChangedListener;
     _addListeners();
-    return _checkIfEnabled();
+    return checkIfEnabled();
   }
 
   void dispose() {
@@ -26,10 +26,10 @@ class QuestionnaireItemEnableWhenController {
   }
 
   void _onControllerChange() {
-    _checkIfEnabled();
+    checkIfEnabled();
   }
 
-  bool _checkIfEnabled() {
+  bool checkIfEnabled({bool notify = true}) {
     bool enabled = _behavior.init();
     for (final enableWhenBundle in _enableWhenBundleList) {
       final controller = enableWhenBundle.controller;
@@ -115,7 +115,9 @@ class QuestionnaireItemEnableWhenController {
         break;
       }
     }
-    _onEnabledChanged?.call(enabled);
+    if (notify) {
+      _onEnabledChanged?.call(enabled);
+    }
     return enabled;
   }
 


### PR DESCRIPTION
Making this method public so that it can be accessible from outside. One of the benefits is the logic for checking whether an item is enabled or not can be reusable. This method is very useful a lot when someone is trying to extend and customize a controller.