### PR TITLE
Questionnaire response item mapper

### DIFF
--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -4,6 +4,16 @@ import 'package:fhir_questionnaire/fhir_questionnaire.dart';
 import 'package:flutter/foundation.dart';
 
 class QuestionnaireController {
+  QuestionnaireController();
+
+  /// Allows modification on a [QuestionnaireResponseItem] when generating
+  /// the [QuestionnaireResponse] object. This callback would be a great
+  /// to add extensions on a [QuestionnaireResponseItem].
+  QuestionnaireResponseItem Function(
+    QuestionnaireItemBundle questionnaireItemBundle,
+    QuestionnaireResponseItem item,
+  )? questionnaireResponseItemMapper;
+
   QuestionnaireItemView? buildChoiceItemView(
       {required QuestionnaireItem item,
       QuestionnaireItemEnableWhenController? enableWhenController}) {
@@ -350,12 +360,18 @@ class QuestionnaireController {
         default:
       }
 
-      items.add(QuestionnaireResponseItem(
+      var item = QuestionnaireResponseItem(
         linkId: itemBundle.item.linkId,
         definition: itemBundle.item.definition,
         text: itemBundle.item.text,
         answer: answers.isEmpty ? null : answers,
-      ));
+      );
+
+      if (questionnaireResponseItemMapper != null) {
+        item = questionnaireResponseItemMapper!.call(itemBundle, item);
+      }
+
+      items.add(item);
     }
 
     return items;

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -4,7 +4,9 @@ import 'package:fhir_questionnaire/fhir_questionnaire.dart';
 import 'package:flutter/foundation.dart';
 
 class QuestionnaireController {
-  QuestionnaireController();
+  QuestionnaireController({
+    this.questionnaireResponseItemMapper,
+  });
 
   /// Allows modification on a [QuestionnaireResponseItem] when generating
   /// the [QuestionnaireResponse] object. This callback would be a great


### PR DESCRIPTION
This will add the possibility to modify a `QuestionnaireResponseItem` after it was generated within `QuestionnaireController`.

This could be a useful addition. There could be use cases which it is required to modify a `QuestionnaireResponseItem` object after it has been created. eg: Adding additional extensions to it.