### PR TITLE
Update QuestionnaireController

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -283,18 +283,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -323,18 +323,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -114,6 +114,7 @@ class QuestionnaireController {
     QuestionnaireItemEnableWhenController? enableWhenController,
     Future<Attachment?> Function()? onAttachmentLoaded,
     String? groupId,
+    List<QuestionnaireItemBundle>? alreadyBuiltItemBundles,
   }) {
     QuestionnaireItemView? itemView;
     List<QuestionnaireItemBundle>? children;
@@ -126,6 +127,7 @@ class QuestionnaireController {
       item.item,
       onAttachmentLoaded: onAttachmentLoaded,
       groupId: groupIdForChildren,
+      alreadyBuiltItemBundles: alreadyBuiltItemBundles,
     );
 
     itemView = onBuildItemView?.call(
@@ -234,17 +236,26 @@ class QuestionnaireController {
     List<QuestionnaireItem>? questionnaireItems, {
     required Future<Attachment?> Function()? onAttachmentLoaded,
     String? groupId,
+    List<QuestionnaireItemBundle>? alreadyBuiltItemBundles,
   }) {
     List<QuestionnaireItemBundle> itemBundles = [];
     try {
       for (final QuestionnaireItem item in questionnaireItems ?? []) {
         QuestionnaireItemEnableWhenController? enableWhenController =
-            getEnableWhenController(item: item, itemBundles: itemBundles);
+            getEnableWhenController(item: item, itemBundles: [
+          ...(alreadyBuiltItemBundles ?? []),
+          ...itemBundles,
+        ]);
+
         final itemBundle = buildQuestionnaireItemBundle(
           item: item,
           enableWhenController: enableWhenController,
           onAttachmentLoaded: onAttachmentLoaded,
           groupId: groupId,
+          alreadyBuiltItemBundles: [
+            ...(alreadyBuiltItemBundles ?? []),
+            ...itemBundles,
+          ],
         );
         if (itemBundle != null) {
           itemBundles.add(itemBundle);
@@ -665,7 +676,7 @@ class QuestionnaireController {
         break;
 
       case QuestionnaireItemType.group:
-      // The answers of a group are the answers of the children
+        // The answers of a group are the answers of the children
         break;
       default:
     }

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -115,114 +115,108 @@ class QuestionnaireController {
     Future<Attachment?> Function()? onAttachmentLoaded,
     String? groupId,
   }) {
-    final itemViewOverride = onBuildItemView?.call(
+    QuestionnaireItemView? itemView;
+    List<QuestionnaireItemBundle>? children;
+    final itemType = QuestionnaireItemType.valueOf(item.type.value);
+
+    final groupIdForChildren =
+        '${groupId != null ? "$groupId/" : ""}${item.linkId}';
+
+    children = buildQuestionnaireItemBundles(
+      item.item,
+      onAttachmentLoaded: onAttachmentLoaded,
+      groupId: groupIdForChildren,
+    );
+
+    itemView = onBuildItemView?.call(
       item,
       enableWhenController,
       onAttachmentLoaded,
     );
 
-    if (itemViewOverride != null) {
-      return QuestionnaireItemBundle(
-        groupId: groupId,
-        item: item,
-        controller: itemViewOverride.controller,
-        view: itemViewOverride,
-      );
-    }
-
-    QuestionnaireItemView? itemView;
-    List<QuestionnaireItemBundle>? children;
-    final itemType = QuestionnaireItemType.valueOf(item.type.value);
-
-    switch (itemType) {
-      case QuestionnaireItemType.string:
-        itemView = QuestionnaireStringItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.text:
-        itemView = QuestionnaireTextItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.integer:
-        itemView = QuestionnaireIntegerItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.decimal:
-        itemView = QuestionnaireDecimalItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.boolean:
-        itemView = QuestionnaireBooleanItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.choice:
-        itemView = buildChoiceItemView(
-            item: item, enableWhenController: enableWhenController);
-        break;
-      case QuestionnaireItemType.openChoice:
-        itemView = buildOpenChoiceItemView(
-            item: item, enableWhenController: enableWhenController);
-        break;
-      case QuestionnaireItemType.date:
-      case QuestionnaireItemType.time:
-      case QuestionnaireItemType.dateTime:
-        itemView = QuestionnaireDateTimeItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-          type: DateTimeType.fromQuestionnaireItemType(itemType),
-        );
-        break;
-      case QuestionnaireItemType.quantity:
-        itemView = QuestionnaireQuantityItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.url:
-        itemView = QuestionnaireUrlItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.display:
-        itemView = QuestionnaireDisplayItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.attachment:
-        itemView = QuestionnaireAttachmentItemView(
-          item: item,
-          onAttachmentLoaded: onAttachmentLoaded,
-          enableWhenController: enableWhenController,
-        );
-        break;
-      case QuestionnaireItemType.group:
-        final groupIdForChildren =
-            '${groupId != null ? "$groupId/" : ""}${item.linkId}';
-
-        children = buildQuestionnaireItemBundles(
-          item.item,
-          onAttachmentLoaded: onAttachmentLoaded,
-          groupId: groupIdForChildren,
-        );
-        itemView = QuestionnaireGroupItemView(
-          item: item,
-          enableWhenController: enableWhenController,
-          children: children.map((itemBundle) => itemBundle.view).toList(),
-        );
-        break;
-      default:
+    if (itemView == null) {
+      switch (itemType) {
+        case QuestionnaireItemType.string:
+          itemView = QuestionnaireStringItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.text:
+          itemView = QuestionnaireTextItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.integer:
+          itemView = QuestionnaireIntegerItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.decimal:
+          itemView = QuestionnaireDecimalItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.boolean:
+          itemView = QuestionnaireBooleanItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.choice:
+          itemView = buildChoiceItemView(
+              item: item, enableWhenController: enableWhenController);
+          break;
+        case QuestionnaireItemType.openChoice:
+          itemView = buildOpenChoiceItemView(
+              item: item, enableWhenController: enableWhenController);
+          break;
+        case QuestionnaireItemType.date:
+        case QuestionnaireItemType.time:
+        case QuestionnaireItemType.dateTime:
+          itemView = QuestionnaireDateTimeItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+            type: DateTimeType.fromQuestionnaireItemType(itemType),
+          );
+          break;
+        case QuestionnaireItemType.quantity:
+          itemView = QuestionnaireQuantityItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.url:
+          itemView = QuestionnaireUrlItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.display:
+          itemView = QuestionnaireDisplayItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.attachment:
+          itemView = QuestionnaireAttachmentItemView(
+            item: item,
+            onAttachmentLoaded: onAttachmentLoaded,
+            enableWhenController: enableWhenController,
+          );
+          break;
+        case QuestionnaireItemType.group:
+          itemView = QuestionnaireGroupItemView(
+            item: item,
+            enableWhenController: enableWhenController,
+            children: children.map((itemBundle) => itemBundle.view).toList(),
+          );
+          break;
+        default:
+      }
     }
 
     return itemView != null

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -6,9 +6,11 @@ import 'package:flutter/foundation.dart';
 
 class QuestionnaireController {
   /// Allows to override the function to generate individual item response
-  QuestionnaireResponseItem? Function({
-    required QuestionnaireItemBundle itemBundle,
-  })? onGenerateItemResponse;
+  /// either to generate a new [QuestionnaireResponseItem] or modify the generated one
+  QuestionnaireResponseItem Function(
+    QuestionnaireItemBundle itemBundle,
+    QuestionnaireResponseItem questionnaireResponseItem,
+  )? onGenerateItemResponse;
 
   QuestionnaireItemBundle? Function({
     required QuestionnaireItem item,
@@ -563,9 +565,6 @@ class QuestionnaireController {
 
   QuestionnaireResponseItem? generateItemResponse(
       QuestionnaireItemBundle itemBundle) {
-    final itemResponseOverride = onGenerateItemResponse?.call(itemBundle: itemBundle);
-    if (itemResponseOverride != null) return itemResponseOverride;
-
     List<QuestionnaireResponseItem>? childItems;
     List<QuestionnaireResponseAnswer>? answers;
     final itemType = QuestionnaireItemType.valueOf(itemBundle.item.type.value);
@@ -663,7 +662,8 @@ class QuestionnaireController {
         break;
       default:
     }
-    return QuestionnaireResponseItem(
+
+    var item = QuestionnaireResponseItem(
       linkId: itemBundle.item.linkId,
       definition: itemBundle.item.definition,
       text: itemBundle.item.text,
@@ -671,6 +671,15 @@ class QuestionnaireController {
       item: childItems,
       extension_: itemBundle.item.extension_,
     );
+
+    if (onGenerateItemResponse != null) {
+      item = onGenerateItemResponse!.call(
+        itemBundle: itemBundle,
+        questionnaireResponseItem: item,
+      );
+    }
+
+    return item;
   }
 
   List<QuestionnaireResponseItem> generateItemResponses(

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -574,6 +574,10 @@ class QuestionnaireController {
     List<QuestionnaireResponseItem>? childItems;
     List<QuestionnaireResponseAnswer>? answers;
     final itemType = QuestionnaireItemType.valueOf(itemBundle.item.type.value);
+    if (itemBundle.children.isNotEmpty) {
+      childItems = generateItemResponses(itemBundles: itemBundle.children!);
+    }
+
     switch (itemType) {
       case QuestionnaireItemType.display:
 
@@ -660,11 +664,8 @@ class QuestionnaireController {
               ];
         break;
 
-      /// The answers of a group are the answers of the children
       case QuestionnaireItemType.group:
-        if (itemBundle.children.isNotEmpty) {
-          childItems = generateItemResponses(itemBundles: itemBundle.children!);
-        }
+      // The answers of a group are the answers of the children
         break;
       default:
     }

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -83,6 +83,8 @@ class QuestionnaireController {
     required QuestionnaireItem item,
     required List<QuestionnaireItemBundle> itemBundles,
   }) {
+    itemBundles = _flattenItemBundles(itemBundles);
+    
     QuestionnaireItemEnableWhenController? controller;
     if (item.enableWhen.isNotEmpty) {
       List<QuestionnaireItemEnableWhenBundle> list = [];
@@ -106,6 +108,8 @@ class QuestionnaireController {
         );
       }
     }
+
+    print('SSS ${item.prefix}: enableWhenController: $controller');
     return controller;
   }
 
@@ -708,5 +712,24 @@ class QuestionnaireController {
     }
 
     return items;
+  }
+
+  /// Takes a list [QuestionnaireItemBundle] flattens it by extracting all the
+  /// child items and putting them all in one list.
+  ///
+  /// Can be used for searching/filtering a list of [QuestionnaireItemBundle] objects.
+  List<QuestionnaireItemBundle> _flattenItemBundles(
+    List<QuestionnaireItemBundle> itemBundles,
+  ) {
+    final flattenedList = <QuestionnaireItemBundle>[];
+
+    for (var itemBundle in itemBundles) {
+      flattenedList.add(itemBundle);
+      if (itemBundle.children?.isNotEmpty == true) {
+        flattenedList.addAll(_flattenItemBundles(itemBundle.children!));
+      }
+    }
+
+    return flattenedList;
   }
 }


### PR DESCRIPTION
This PR introduces a few fixes and improvements in `QuestionnaireController` class.

1. Fixes only rendering nested questionnaire items that were a child of a QuestionnaireItem of type `group`. In FHIR any `QuestionnaireItem` can have child items. eg a `QuestionnaireItem` of type text, group, questions can have child items of any type. or any `QuestionnaireItem` can have a child display item with extension coding of `help` acting as the help text of the parent item. (Also done the same for generating QuestionnaireResponseItem objects) 
2. Updates the `onGenerateItemResponse` callback method to also provide the generated `QuestionnaireResponseItem` as an argument of this callback. This way when this callback is being implemented it is also possible to just modify the `QuestionnaireResponseItem` and return it. Many times it is only desired to modify a field or add an extra extension to a generated `QuestionnaireResponseItem` of certain type and just return it. Other than that it is required, since each generated `QuestionnaireResponseItem` can have generated children items. So by simply not providing the generated QuestionnaireResponseItem, its children are not being provided as well in the callback.
3. Converts `onBuildItemBundle` to `onBuildItemView` since almost always it is just desired to render a custom item view to be rendered for a type of questionnaireItem. To delegate the entire generation of `QuestionnaireBundleItem` in the callback will be much harder for the implementors, If all they want is to just custom render a questionnaire item, the responsibility to also generate children and groupIds shouldn't fall to them.
4. Fixes the enableWhen not working when the `enable.question` was not in the same group 