### PR TITLE
Fix text field starting to validate input before user types anything

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -283,18 +283,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -323,18 +323,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/lib/src/presentation/widgets/custom_text_field.dart
+++ b/lib/src/presentation/widgets/custom_text_field.dart
@@ -196,6 +196,7 @@ class CustomTextField extends StatefulWidget {
 class CustomTextFieldState<S extends CustomTextField> extends State<S> {
   late final CustomTextEditingController controller;
   String lastText = '';
+  bool startedTyping = false;
 
   CustomTextFieldState();
 
@@ -257,6 +258,9 @@ class CustomTextFieldState<S extends CustomTextField> extends State<S> {
   }
 
   void onChanged(String value) {
+    if (value.isNotEmpty) {
+      startedTyping = true;
+    }
     bool refreshState = autoValidate && onValidate(value);
     if (hadText != value.isNotEmpty) {
       refreshState |= true;
@@ -282,7 +286,10 @@ class CustomTextFieldState<S extends CustomTextField> extends State<S> {
     } else {
       final wasValid = !controller.hasError;
       final lastError = controller.error;
-      final isValid = controller.validate(notify: false);
+      var isValid = true;
+      if (startedTyping) {
+        isValid = controller.validate(notify: false);
+      }
       final currentError = controller.error;
       if (isValid) {
         controller.clearError();

--- a/lib/src/presentation/widgets/custom_text_field.dart
+++ b/lib/src/presentation/widgets/custom_text_field.dart
@@ -254,13 +254,15 @@ class CustomTextFieldState<S extends CustomTextField> extends State<S> {
   bool get showCustomButton => widget.useCustomButton && hasText;
 
   void onControllerTextChanged() {
-    onChanged(controller.text);
+    if (controller.text.isNotEmpty) {
+      startedTyping = true;
+    }
+    if (startedTyping) {
+      onChanged(controller.text);
+    }
   }
 
   void onChanged(String value) {
-    if (value.isNotEmpty) {
-      startedTyping = true;
-    }
     bool refreshState = autoValidate && onValidate(value);
     if (hadText != value.isNotEmpty) {
       refreshState |= true;
@@ -286,10 +288,7 @@ class CustomTextFieldState<S extends CustomTextField> extends State<S> {
     } else {
       final wasValid = !controller.hasError;
       final lastError = controller.error;
-      var isValid = true;
-      if (startedTyping) {
-        isValid = controller.validate(notify: false);
-      }
+      final isValid = controller.validate(notify: false);
       final currentError = controller.error;
       if (isValid) {
         controller.clearError();


### PR DESCRIPTION
With following changes, the text fields will no longer show error before user started typing. previously after the error was shown once after refocusing on the textfield for a second time even though the textfield was empty and error was shown indicating that a value is required.