### PR TITLE
Add translation support

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -283,18 +283,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -323,18 +323,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/lib/fhir_questionnaire.dart
+++ b/lib/fhir_questionnaire.dart
@@ -47,6 +47,7 @@ export 'package:fhir_questionnaire/src/presentation/widgets/questionnaire_item/b
 export 'package:fhir_questionnaire/src/presentation/widgets/questionnaire_item/base/questionnaire_text_field_item_view.dart';
 export 'package:fhir_questionnaire/src/presentation/widgets/questionnaire_item/base/questionnaire_multi_choice_item_view.dart';
 export 'package:fhir_questionnaire/src/presentation/widgets/custom_text_field.dart';
+export 'package:fhir_questionnaire/src/presentation/localization/questionnaire_localization_data.dart';
 export 'package:fhir_questionnaire/src/presentation/localization/questionnaire_localization.dart';
 export 'package:fhir_questionnaire/src/presentation/localization/questionnaire_es_localization.dart';
 export 'package:fhir_questionnaire/src/presentation/localization/questionnaire_en_localization.dart';

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -564,8 +564,10 @@ class QuestionnaireController {
   }
 
   QuestionnaireResponseItem? generateItemResponse(
-    QuestionnaireItemBundle itemBundle,
-  ) {
+      QuestionnaireItemBundle itemBundle) {
+    final itemResponseOverride = onGenerateItemResponse?.call(itemBundle: itemBundle);
+    if (itemResponseOverride != null) return itemResponseOverride;
+
     List<QuestionnaireResponseItem>? childItems;
     List<QuestionnaireResponseAnswer>? answers;
     final itemType = QuestionnaireItemType.valueOf(itemBundle.item.type.value);

--- a/lib/src/logic/questionnaire_controller.dart
+++ b/lib/src/logic/questionnaire_controller.dart
@@ -271,7 +271,9 @@ class QuestionnaireController {
       answers.add(QuestionnaireResponseAnswer(
         valueCoding: data.valueCoding,
         valueString: data.valueString,
+        valueStringElement: data.valueStringElement,
         valueInteger: data.valueInteger,
+        valueIntegerElement: data.valueIntegerElement,
       ));
     } else if (data is List<QuestionnaireAnswerOption>) {
       for (final answerOption in data) {
@@ -562,10 +564,8 @@ class QuestionnaireController {
   }
 
   QuestionnaireResponseItem? generateItemResponse(
-      QuestionnaireItemBundle itemBundle) {
-    final itemResponseOverride = onGenerateItemResponse?.call(itemBundle: itemBundle);
-    if (itemResponseOverride != null) return itemResponseOverride;
-
+    QuestionnaireItemBundle itemBundle,
+  ) {
     List<QuestionnaireResponseItem>? childItems;
     List<QuestionnaireResponseAnswer>? answers;
     final itemType = QuestionnaireItemType.valueOf(itemBundle.item.type.value);
@@ -666,7 +666,9 @@ class QuestionnaireController {
     return QuestionnaireResponseItem(
       linkId: itemBundle.item.linkId,
       definition: itemBundle.item.definition,
+      definitionElement: itemBundle.item.definitionElement,
       text: itemBundle.item.text,
+      textElement: itemBundle.item.textElement,
       answer: answers.isEmpty ? null : answers,
       item: childItems,
       extension_: itemBundle.item.extension_,

--- a/lib/src/logic/utils/fhir_extensions_utils.dart
+++ b/lib/src/logic/utils/fhir_extensions_utils.dart
@@ -1,0 +1,30 @@
+import 'package:collection/collection.dart';
+import 'package:fhir/r4.dart';
+
+const _fhirTranslationExtension =
+    'http://hl7.org/fhir/StructureDefinition/translation';
+
+extension FhirExtensionUtils on Iterable<FhirExtension> {
+  String? translationForLocale(String locale) {
+    final allTranslations =
+        where((ext) => ext.url?.toString() == _fhirTranslationExtension);
+
+    if (allTranslations.isEmpty) {
+      return null;
+    } else {
+      final match = allTranslations.firstWhereOrNull((translation) {
+        return translation.extension_?.firstWhereOrNull((ext) =>
+                ext.url?.toString() == 'lang' &&
+                ext.valueCode?.toString() == locale) !=
+            null;
+      });
+
+      if (match != null) {
+        final content = match.extension_
+            ?.firstWhereOrNull((ext) => ext.url?.toString() == 'content');
+
+        return content?.valueString ?? content?.valueMarkdown?.toString();
+      }
+    }
+  }
+}

--- a/lib/src/logic/utils/iterable_utils.dart
+++ b/lib/src/logic/utils/iterable_utils.dart
@@ -155,3 +155,4 @@ extension MapNullExtension on Map? {
   bool get isEmpty => this == null || (this as Map).isEmpty;
   bool get isNotEmpty => !isEmpty;
 }
+

--- a/lib/src/logic/utils/questionnaire_utils.dart
+++ b/lib/src/logic/utils/questionnaire_utils.dart
@@ -1,11 +1,27 @@
 import 'package:fhir/r4.dart';
+import 'package:fhir_questionnaire/fhir_questionnaire.dart';
+import 'package:fhir_questionnaire/src/logic/utils/fhir_extensions_utils.dart';
+import 'package:flutter/material.dart';
 
 extension CodeableConceptUtils on CodeableConcept {
-  String? get title => text ?? coding?.firstOrNull?.title;
+  String? title(final BuildContext context) {
+    final locale = QuestionnaireLocalization.of(context).localization.locale;
+
+    final textLocalized =
+        textElement?.extension_?.translationForLocale(locale) ?? text;
+
+    return textLocalized ?? coding?.firstOrNull?.title(context);
+  }
 }
 
 extension CodingUtils on Coding {
-  String? get title => display ?? code?.value ?? system?.value?.toString();
+  String?  title(final BuildContext context) {
+    final locale = QuestionnaireLocalization.of(context).localization.locale;
+    final displayLocalized =
+        displayElement?.extension_?.translationForLocale(locale) ?? display;
+
+    return displayLocalized ?? code?.value ?? system?.value?.toString();
+  }
 }
 
 extension FhirDateUtils on FhirDate {
@@ -23,10 +39,24 @@ extension FhirDateTimeUtils on FhirDateTime {
 }
 
 extension QuestionnaireItemUtils on QuestionnaireItem {
-  String? get title => text ?? code?.firstOrNull?.title;
+  String? title(final BuildContext context) {
+    final locale = QuestionnaireLocalization.of(context).localization.locale;
+
+    final textLocalized =
+        textElement?.extension_?.translationForLocale(locale) ?? text;
+    return textLocalized ?? code?.firstOrNull?.title(context);
+  }
 }
 
 extension QuestionnaireUtils on Questionnaire {
   FhirCanonical get asFhirCanonical =>
       FhirCanonical('${R4ResourceType.Questionnaire.name}/$fhirId');
+}
+
+extension QuestionnaireAnswerOptionUtils on QuestionnaireAnswerOption {
+  String? valueStringLocalized(final BuildContext context) {
+    final locale = QuestionnaireLocalization.of(context).localization.locale;
+    return valueStringElement?.extension_?.translationForLocale(locale) ??
+        valueString;
+  }
 }

--- a/lib/src/presentation/localization/questionnaire_localization.dart
+++ b/lib/src/presentation/localization/questionnaire_localization.dart
@@ -1,33 +1,55 @@
-import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_base_localization.dart';
-import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_en_localization.dart';
-import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_es_localization.dart';
+import 'package:collection/collection.dart';
+import 'package:fhir_questionnaire/fhir_questionnaire.dart';
+import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_localization_data.dart';
+import 'package:flutter/material.dart';
 
-class QuestionnaireLocalization {
-  static final instance = QuestionnaireLocalization();
-  QuestionnaireBaseLocalization localization = QuestionnaireEnLocalization();
-  QuestionnaireBaseLocalization _defaultLocalization =
-      QuestionnaireEnLocalization();
-  final Map<String, QuestionnaireBaseLocalization> _localizationsMap = {
-    'en': QuestionnaireEnLocalization(),
-    'es': QuestionnaireEsLocalization(),
-  };
-  QuestionnaireLocalization();
+class QuestionnaireLocalization extends InheritedWidget {
+  final QuestionnaireLocalizationData data;
+  static QuestionnaireLocalizationData? _currentInstance;
+  static QuestionnaireLocalizationData get current {
+    if (_currentInstance == null) {
+      throw Exception(
+        'The QuestionnaireLocalizationData has not been set yet '
+        'It will be done after an instance of QuestionnaireLocalization widget has been instantiated',
+      );
+    }
 
-  void init({
-    QuestionnaireBaseLocalization? defaultLocalization,
-    List<QuestionnaireBaseLocalization>? localizations,
-    String? locale,
+    return _currentInstance!;
+  }
+
+  QuestionnaireLocalization({
+    super.key,
+    required this.data,
+    required super.child,
   }) {
-    if (defaultLocalization != null) {
-      _defaultLocalization = defaultLocalization;
+    _currentInstance = data;
+  }
+
+  static QuestionnaireLocalizationData of(final BuildContext context) {
+    final result = context
+        .dependOnInheritedWidgetOfExactType<QuestionnaireLocalization>()
+        ?.data;
+    if (result == null) {
+      throw Exception(
+        'Could not find an instance of QuestionnaireLocalizationData when called '
+        'QuestionnaireLocalization.of(context) in the widget tree. '
+        'One can be inserted into the widget tree using QuestionnaireLocalization widget',
+      );
     }
-    if (localizations != null) {
-      for (final localization in localizations) {
-        _localizationsMap[localization.locale] = localization;
-      }
-    }
-    if (locale != null) {
-      localization = _localizationsMap[locale] ?? _defaultLocalization;
-    }
+
+    return result;
+  }
+
+  @override
+  bool updateShouldNotify(final QuestionnaireLocalization oldWidget) {
+    return oldWidget.data.localization.locale != data.localization.locale ||
+        !const DeepCollectionEquality().equals(
+          data.fallbackLocalization,
+          oldWidget.data.fallbackLocalization,
+        ) ||
+        !const DeepCollectionEquality().equals(
+          data.localization,
+          oldWidget.data.localization,
+        );
   }
 }

--- a/lib/src/presentation/localization/questionnaire_localization_data.dart
+++ b/lib/src/presentation/localization/questionnaire_localization_data.dart
@@ -1,0 +1,23 @@
+import 'package:collection/collection.dart';
+import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_base_localization.dart';
+
+class QuestionnaireLocalizationData {
+  QuestionnaireLocalizationData({
+    required this.locale,
+    required this.fallbackLocalization,
+    required List<QuestionnaireBaseLocalization> localizations,
+  }) {
+    for (final localization in localizations) {
+      _localizationsMap[localization.locale] = localization;
+    }
+  }
+
+  final String locale;
+  final QuestionnaireBaseLocalization fallbackLocalization;
+  final Map<String, QuestionnaireBaseLocalization> _localizationsMap = {};
+
+  QuestionnaireBaseLocalization get localization =>
+      _localizationsMap[locale] ?? fallbackLocalization;
+
+
+}

--- a/lib/src/presentation/utils/validation_utils.dart
+++ b/lib/src/presentation/utils/validation_utils.dart
@@ -1,27 +1,31 @@
+import 'package:fhir/r4.dart';
 import 'package:fhir_questionnaire/src/presentation/localization/questionnaire_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fhir_questionnaire/src/logic/utils/num_utils.dart';
 import 'package:fhir_questionnaire/src/logic/utils/text_utils.dart';
+import 'package:flutter/widgets.dart';
 
 class ValidationUtils {
-  static ValidationController get requiredFieldValidation =>
-      EnhancedEmptyValidationController(
-          message: QuestionnaireLocalization
-              .instance.localization.exceptionNoEmptyField);
+  static ValidationController requiredFieldValidation() =>
+      EnhancedEmptyValidationController();
 
-  static ValidationController get positiveIntegerNumberValidation =>
+  static ValidationController positiveIntegerNumberValidation(
+          BuildContext context) =>
       PositiveIntegerValidationController(
-          message: QuestionnaireLocalization.instance.localization
+          message: QuestionnaireLocalization.of(context)
+              .localization
               .exceptionValueMustBeAPositiveIntegerNumber);
 
   static ValidationController positiveNumberValidation({
+    required BuildContext context,
     String? message,
     bool required = false,
   }) =>
       ValidationController(
           message: message ??
-              QuestionnaireLocalization
-                  .instance.localization.exceptionValueMustBeAPositiveNumber,
+              QuestionnaireLocalization.of(context)
+                  .localization
+                  .exceptionValueMustBeAPositiveNumber,
           isValid: ({controller}) {
             String? textValue = controller?.rawValue?.toString();
             if (!required && textValue.isEmpty) return true;
@@ -29,27 +33,35 @@ class ValidationUtils {
             return (value ?? -1) >= 0;
           });
 
-  static ValidationController integerRangeValidationController(
-          {required int minValue, required int maxValue}) =>
+  static ValidationController integerRangeValidationController({
+    required BuildContext context,
+    required int minValue,
+    required int maxValue,
+  }) =>
       IntegerRangeValidationController(
-        message: QuestionnaireLocalization.instance.localization
+        message: QuestionnaireLocalization.of(context)
+            .localization
             .exceptionValueOutOfRange(minValue, maxValue),
         minValue: minValue,
         maxValue: maxValue,
       );
 
-  static List<ValidationController>
-      get requiredPositiveIntegerNumberValidations => [
-            requiredFieldValidation,
-            positiveIntegerNumberValidation,
-          ];
+  static List<ValidationController> requiredPositiveIntegerNumberValidations(
+          BuildContext context) =>
+      [
+        requiredFieldValidation(),
+        positiveIntegerNumberValidation(context),
+      ];
 
-  static List<ValidationController> get requiredPositiveNumberValidations => [
-        requiredFieldValidation,
-        positiveNumberValidation(),
+  static List<ValidationController> requiredPositiveNumberValidations(
+          BuildContext context) =>
+      [
+        requiredFieldValidation(),
+        positiveNumberValidation(context: context),
       ];
 
   static ValidationController lengthValidation({
+    required BuildContext context,
     int minLength = 0,
     int? maxLength,
     String? message,
@@ -58,7 +70,8 @@ class ValidationUtils {
   }) =>
       ValidationController(
           message: message ??
-              QuestionnaireLocalization.instance.localization
+              QuestionnaireLocalization.of(context)
+                  .localization
                   .exceptionTextLength(minLength, maxLength ?? (minLength * 2)),
           isValid: ({controller}) {
             String textValue = controller?.rawValue?.toString().trim() ?? '';
@@ -72,13 +85,15 @@ class ValidationUtils {
 
   static ValidationController maxLengthValidation({
     required int maxLength,
+    required BuildContext context,
     String? message,
     bool required = false,
     bool considerExtendedCharacters = true,
   }) =>
       ValidationController(
           message: message ??
-              QuestionnaireLocalization.instance.localization
+              QuestionnaireLocalization.of(context)
+                  .localization
                   .exceptionTextMaxLength(maxLength),
           isValid: ({controller}) {
             String textValue = controller?.rawValue?.toString().trim() ?? '';
@@ -92,21 +107,34 @@ class ValidationUtils {
   static ValidationController urlValidation({
     String? message,
     bool required = false,
+    required BuildContext context,
   }) =>
       UrlValidationController(
         message: message ??
-            QuestionnaireLocalization.instance.localization.exceptionInvalidUrl,
+            QuestionnaireLocalization.of(context)
+                .localization
+                .exceptionInvalidUrl,
         required: required,
       );
 }
 
 class EnhancedEmptyValidationController extends ValidationController {
-  EnhancedEmptyValidationController({String? message})
-      : super(
-          message: message ??
-              QuestionnaireLocalization
-                  .instance.localization.exceptionNoEmptyField,
-          isValid: ({controller}) =>
-              TextUtils.isNotEmpty(controller?.rawValue?.toString().trim()),
+  final String? customMessage;
+
+  EnhancedEmptyValidationController({
+    this.customMessage,
+  }) : super(
+          isValid: ({controller}) {
+            final rawValue = controller?.rawValue;
+            if (rawValue is List<QuestionnaireAnswerOption>) {
+              return rawValue.isNotEmpty;
+            } else {
+              return TextUtils.isNotEmpty(rawValue?.toString().trim());
+            }
+          },
         );
+
+  @override
+  String? get message => customMessage ??
+      QuestionnaireLocalization.current.localization.exceptionNoEmptyField;
 }

--- a/lib/src/presentation/widgets/questionnaire_item/attachment/questionnaire_attachment_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/attachment/questionnaire_attachment_item_view.dart
@@ -49,7 +49,7 @@ class QuestionnaireAttachmentItemViewState
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(
               left: 8.0,
@@ -57,7 +57,7 @@ class QuestionnaireAttachmentItemViewState
               bottom: 4.0,
             ),
             child: Text(
-              item.title!,
+              item.title(context)!,
               style: Theme.of(context).textTheme.titleSmall,
             ),
           ),
@@ -102,9 +102,9 @@ class QuestionnaireAttachmentItemViewState
                           value == null ? Icons.upload_rounded : Icons.refresh),
                       label: Text(value == null
                           ? QuestionnaireLocalization
-                              .instance.localization.btnUpload
+                              .of(context).localization.btnUpload
                           : QuestionnaireLocalization
-                              .instance.localization.btnChange),
+                              .of(context).localization.btnChange),
                     ),
                   ),
                 ),
@@ -129,7 +129,7 @@ class QuestionnaireAttachmentItemViewState
                       ),
                       icon: const Icon(Icons.delete_forever_rounded),
                       label: Text(QuestionnaireLocalization
-                          .instance.localization.btnRemove),
+                          .of(context).localization.btnRemove),
                     ),
                   ),
                 ),

--- a/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_choice_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_choice_item_view.dart
@@ -36,21 +36,21 @@ abstract class QuestionnaireChoiceItemViewState<
 
   bool get isOpen => widget.isOpen;
   String valueNameResolver(QuestionnaireAnswerOption value) =>
-      value.valueCoding?.title ??
-      value.valueString ??
+      value.valueCoding?.title(context) ??
+      value.valueStringLocalized(context) ??
       value.valueInteger?.toString() ??
       '';
 
   QuestionnaireAnswerOption onOpenAnswerAdded(String value,
       {bool? hideKeyboard}) {
     hideKeyboard ??= true;
-    final anwser = QuestionnaireAnswerOption(valueString: value);
-    values.add(anwser);
+    final answer = QuestionnaireAnswerOption(valueString: value);
+    values.add(answer);
     if (hideKeyboard) {
       InputMethodUtils.hideInputMethod(force: true);
     }
     controller.clearError();
-    return anwser;
+    return answer;
   }
 
   Widget choiceView(BuildContext context);
@@ -61,7 +61,7 @@ abstract class QuestionnaireChoiceItemViewState<
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(
               left: 8.0,
@@ -69,7 +69,7 @@ abstract class QuestionnaireChoiceItemViewState<
               bottom: 4.0,
             ),
             child: Text(
-              item.title!,
+              item.title(context)!,
               style: Theme.of(context).textTheme.titleSmall,
             ),
           ),
@@ -97,7 +97,8 @@ abstract class QuestionnaireChoiceItemViewState<
               bottom: 4.0,
             ),
             child: Text(
-              QuestionnaireLocalization.instance.localization.textOtherOption,
+              QuestionnaireLocalization
+                  .of(context).localization.textOtherOption,
               style: Theme.of(context).textTheme.titleSmall,
             ),
           ),

--- a/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_item_view.dart
@@ -54,7 +54,7 @@ abstract class QuestionnaireItemViewState<SF extends QuestionnaireItemView>
       controller.addListener(onControllerErrorChanged);
     }
     controller.validations.addAll([
-      if (isRequired) ValidationUtils.requiredFieldValidation,
+      if (isRequired) ValidationUtils.requiredFieldValidation(),
     ]);
     isEnabled =
         enableWhenController?.init(onEnabledChangedListener: onEnabled) ?? true;

--- a/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_text_field_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/base/questionnaire_text_field_item_view.dart
@@ -44,7 +44,7 @@ abstract class QuestionnaireTextFieldItemViewState<
 
     controller.validations.addAll([
       if ((maxLength ?? 0) > 0)
-        ValidationUtils.maxLengthValidation(maxLength: maxLength!),
+        ValidationUtils.maxLengthValidation(maxLength: maxLength!, context: context),
     ]);
   }
 
@@ -61,7 +61,7 @@ abstract class QuestionnaireTextFieldItemViewState<
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(
               left: 8.0,
@@ -69,7 +69,7 @@ abstract class QuestionnaireTextFieldItemViewState<
               bottom: 4.0,
             ),
             child: Text(
-              item.title!,
+              item.title(context)!,
               style: Theme.of(context).textTheme.titleSmall,
             ),
           ),

--- a/lib/src/presentation/widgets/questionnaire_item/boolean/questionnaire_boolean_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/boolean/questionnaire_boolean_item_view.dart
@@ -47,7 +47,7 @@ class QuestionnaireBooleanItemViewState
       value: value,
       onChanged:
           isReadOnly ? null : (value) => setState(() => this.value = value),
-      title: item.title.isEmpty ? null : Text(item.title!),
+      title: item.title(context).isEmpty ? null : Text(item.title(context)!),
       contentPadding: const EdgeInsets.only(left: 8),
     );
   }

--- a/lib/src/presentation/widgets/questionnaire_item/date/questionnaire_date_time_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/date/questionnaire_date_time_item_view.dart
@@ -78,11 +78,11 @@ class QuestionnaireDateTimeItemViewState
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 4.0),
             child: Text(
-              item.title!,
+              item.title(context)!,
               style: theme.textTheme.titleSmall,
             ),
           ),
@@ -96,8 +96,9 @@ class QuestionnaireDateTimeItemViewState
                   return ElevatedButton.icon(
                       icon: const Icon(Icons.calendar_month),
                       label: Text(dateTime?.formattedDate() ??
-                          QuestionnaireLocalization
-                              .instance.localization.textDate),
+                          QuestionnaireLocalization.of(context)
+                              .localization
+                              .textDate),
                       style: ElevatedButton.styleFrom(padding: EdgeInsets.zero),
                       onPressed: openDatePicker);
                 }),
@@ -113,8 +114,9 @@ class QuestionnaireDateTimeItemViewState
                   return ElevatedButton.icon(
                       icon: const Icon(Icons.access_time_rounded),
                       label: Text(dateTime?.formattedTime() ??
-                          QuestionnaireLocalization
-                              .instance.localization.textTime),
+                          QuestionnaireLocalization.of(context)
+                              .localization
+                              .textTime),
                       style: ElevatedButton.styleFrom(padding: EdgeInsets.zero),
                       onPressed: openTimePicker);
                 }),

--- a/lib/src/presentation/widgets/questionnaire_item/group/questionnaire_group_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/group/questionnaire_group_item_view.dart
@@ -52,7 +52,7 @@ class QuestionnaireGroupItemViewState
                   children: children!.map((itemView) => itemView).toList(),
                 ),
         ),
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Positioned(
               left: 16,
               right: 16,

--- a/lib/src/presentation/widgets/questionnaire_item/quantity/questionnaire_quantity_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/quantity/questionnaire_quantity_item_view.dart
@@ -71,7 +71,7 @@ class QuestionnaireQuantityItemViewState
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (item.title.isNotEmpty)
+        if (item.title(context).isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(
               left: 8.0,
@@ -79,7 +79,7 @@ class QuestionnaireQuantityItemViewState
               bottom: 4.0,
             ),
             child: Text(
-              item.title!,
+              item.title(context)!,
               style: Theme.of(context).textTheme.titleSmall,
             ),
           ),

--- a/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_decimal_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_decimal_item_view.dart
@@ -19,8 +19,12 @@ class QuestionnaireDecimalItemViewState
   @override
   void initState() {
     super.initState();
-    controller.validations.addAll(
-        [ValidationUtils.positiveNumberValidation(required: isRequired)]);
+    controller.validations.addAll([
+      ValidationUtils.positiveNumberValidation(
+        required: isRequired,
+        context: context,
+      ),
+    ]);
   }
 
   @override

--- a/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_integer_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_integer_item_view.dart
@@ -19,8 +19,10 @@ class QuestionnaireIntegerItemViewState
   @override
   void initState() {
     super.initState();
-    controller.validations.addAll(
-        [ValidationUtils.positiveNumberValidation(required: isRequired)]);
+    controller.validations.addAll([
+      ValidationUtils.positiveNumberValidation(
+          required: isRequired, context: context),
+    ]);
   }
 
   @override

--- a/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_url_item_view.dart
+++ b/lib/src/presentation/widgets/questionnaire_item/text_input/questionnaire_url_item_view.dart
@@ -19,7 +19,9 @@ class QuestionnaireUrlItemViewState
   @override
   void initState() {
     super.initState();
-    controller.validations.add(ValidationUtils.urlValidation());
+    controller.validations.add(ValidationUtils.urlValidation(
+      context: context,
+    ));
   }
 
   @override

--- a/test/fhir_questionnaire_test.dart
+++ b/test/fhir_questionnaire_test.dart
@@ -1,1 +1,0 @@
-void main() {}

--- a/test/fhri_extensions_utils_test.dart
+++ b/test/fhri_extensions_utils_test.dart
@@ -1,0 +1,41 @@
+import 'package:fhir/r4.dart';
+import 'package:fhir_questionnaire/src/logic/utils/fhir_extensions_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'Should extract translation value from translation extension for the title field',
+    () {
+      const jsonString = r'''
+{
+  "resourceType": "Questionnaire",
+  "title": "Health questionnaire",
+  "_title": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+        "extension": [
+          {
+            "url": "lang",
+            "valueCode": "de"
+          },
+          {
+            "url": "content",
+            "valueString": "Gesundheitsfragebogen"
+          }
+        ]
+      }
+    ]
+  },
+  "item": []
+}
+''';
+
+      final questionnaire = Questionnaire.fromJsonString(jsonString);
+      expect(
+        questionnaire.titleElement?.extension_?.translationForLocale('de'),
+        'Gesundheitsfragebogen',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Following changes will update the library to include a translation support for questionnaire and also include the translations in the generated QuestionnaireResponse. 

Based on FHIR specification of [translation extension](https://hl7.org/fhir/extensions/StructureDefinition-translation.html) allowing each property of a FHIR property of a FHIR object to have its own translation inside its extensions.

